### PR TITLE
Hid tldraw style panel in top right for now by changing css

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,11 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Hide the tldraw style panel (color pickers, size selectors, etc.) temporary to reimplement later if needed */
+.tlui-style-panel {
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out;
+  pointer-events: none; /* Prevent interaction when hidden */
+}


### PR DESCRIPTION
Day 3

Problem: Initially struggled to hide the tldraw style panel. Early CSS attempts using only opacity or incorrect selectors were ineffective, as the panel either remained interactive or the hover effects didn't trigger as expected.

Solution: The final CSS solution successfully hides the .tlui-style-panel by default using a combination of opacity: 0, visibility: hidden, and pointer-events: none. This ensures the panel is not only invisible but also removed from the layout flow and non-interactive. 

Learnings & Takeaway: Learned that effectively hiding UI elements requires a multi-faceted CSS approach. Simply setting opacity to zero isn't enough; visibility: hidden and pointer-events: none are crucial for true invisibility and preventing unwanted interactions. For conditional visibility (like hover), targeting a stable parent element to reveal a child is often more reliable than trying to hover the hidden element itself.

Key Takeaway: For robust UI element hiding, combine opacity, visibility, and pointer-events. For hover-to-show, target a parent.