### PR TITLE
Audio player resize/draggable now, removed tldraw dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.49.9",
+        "@types/react-rnd": "^7.4.4",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-rnd": "^10.5.2",
         "tldraw": "^3.13.1",
         "zustand": "^5.0.5"
       },
@@ -3501,7 +3503,6 @@
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
       "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3515,6 +3516,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/react-rnd": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/react-rnd/-/react-rnd-7.4.4.tgz",
+      "integrity": "sha512-Rh9UdKFiV4fxh/05shQsU3RO+eH5anU6eZCo8NBzobEfB6QU50ISLVP24rEZtIXbYsiiwjo7w960aAZ6JicpMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/use-sync-external-store": {
@@ -4533,6 +4543,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -4630,7 +4649,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -6413,7 +6431,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -6823,7 +6840,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -7104,7 +7120,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7409,7 +7424,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -7729,6 +7743,16 @@
         }
       }
     },
+    "node_modules/re-resizable": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.11.2.tgz",
+      "integrity": "sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
@@ -7750,11 +7774,24 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.6.tgz",
+      "integrity": "sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
@@ -7803,6 +7840,27 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-rnd": {
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.5.2.tgz",
+      "integrity": "sha512-0Tm4x7k7pfHf2snewJA8x7Nwgt3LV+58MVEWOVsFjk51eYruFEa6Wy7BNdxt4/lH0wIRsu7Gm3KjSXY2w7YaNw==",
+      "license": "MIT",
+      "dependencies": {
+        "re-resizable": "6.11.2",
+        "react-draggable": "4.4.6",
+        "tslib": "2.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/react-rnd/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "license": "0BSD"
     },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   "dependencies": {
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.49.9",
+    "@types/react-rnd": "^7.4.4",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-rnd": "^10.5.2",
     "tldraw": "^3.13.1",
     "zustand": "^5.0.5"
   },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,3 +32,19 @@ body {
   transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out;
   pointer-events: none; /* Prevent interaction when hidden */
 }
+
+/* Hide the tldraw page selector (usually top-left) */
+.tlui-pages-menu {
+  display: none !important;
+}
+
+/* Hide the tldraw main menu zone (usually top-left, includes hamburger menu and its dropdown) */
+.tlui-menu-zone {
+  display: none !important;
+}
+
+/* As a fallback, or if the above are not specific enough, 
+   this targets a common container for top-left UI elements in tldraw. */
+.tlui-layout__top-left .tlui-buttons__horizontal {
+  display: none !important;
+}

--- a/src/components/Whiteboard.tsx
+++ b/src/components/Whiteboard.tsx
@@ -3,11 +3,35 @@
 import { Tldraw } from "tldraw";
 import "tldraw/tldraw.css";
 import { useAudioStore } from "@/store/audioStore";
-import { useRef } from "react";
+import { useRef, useState, useEffect } from "react";
+import { Rnd } from "react-rnd";
 
 export default function Whiteboard() {
   const { uploadAudio, audioFiles, isUploading } = useAudioStore();
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // State for react-rnd component
+  const [rndSize, setRndSize] = useState({ width: 320, height: 300 });
+  const [rndPosition, setRndPosition] = useState({ x: 0, y: 16 });
+
+  // Set initial position on the right side of the screen
+  useEffect(() => {
+    const updatePosition = () => {
+      setRndPosition({
+        x: window.innerWidth - rndSize.width - 16, // 16px margin from right
+        y: 16, // 16px margin from top
+      });
+    };
+
+    // Set initial position
+    updatePosition();
+
+    // Update position on window resize
+    const handleResize = () => updatePosition();
+    window.addEventListener("resize", handleResize);
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, [rndSize.width]);
 
   const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
@@ -48,7 +72,6 @@ export default function Whiteboard() {
         onChange={handleFileSelect}
         style={{ display: "none" }}
       />
-
       {/* Simple Upload Button */}
       <div className="absolute top-4 left-4 z-50">
         <button
@@ -65,25 +88,49 @@ export default function Whiteboard() {
         >
           {isUploading ? "Uploading..." : "📁 Upload Audio"}
         </button>
-      </div>
-
-      {/* Audio Files List */}
+      </div>{" "}
+      {/* Audio Files List - Resizable and Draggable */}
       {audioFiles.length > 0 && (
-        <div className="absolute top-4 right-4 bg-white p-4 rounded shadow-lg z-50 max-w-80">
-          <h3 className="font-bold mb-2">
-            Uploaded Files ({audioFiles.length})
-          </h3>
-          <div className="max-h-48 overflow-y-auto space-y-2">
-            {audioFiles.map((file) => (
-              <div key={file.id} className="p-2 bg-gray-50 rounded">
-                <p className="text-sm font-medium truncate">{file.filename}</p>
-                <audio controls src={file.url} className="w-full mt-1" />
-              </div>
-            ))}
+        <Rnd
+          size={rndSize}
+          position={rndPosition}
+          onDragStop={(e, d) => {
+            setRndPosition({ x: d.x, y: d.y });
+          }}
+          onResizeStop={(e, direction, ref, delta, position) => {
+            setRndSize({
+              width: parseInt(ref.style.width),
+              height: parseInt(ref.style.height),
+            });
+            setRndPosition(position);
+          }}
+          minWidth={250}
+          minHeight={200}
+          maxWidth={600}
+          maxHeight={800}
+          bounds="parent"
+          dragHandleClassName="drag-handle"
+          className="z-50"
+        >
+          <div className="bg-white p-4 rounded shadow-lg h-full flex flex-col">
+            <h3 className="font-bold mb-2 truncate drag-handle cursor-move">
+              {audioFiles.length === 1
+                ? audioFiles[0].filename
+                : `Demos (${audioFiles.length})`}
+            </h3>
+            <div className="flex-1 overflow-y-auto space-y-2 min-h-0">
+              {audioFiles.map((file) => (
+                <div key={file.id} className="p-2 bg-gray-50 rounded">
+                  <p className="text-sm font-medium truncate">
+                    {file.filename}
+                  </p>
+                  <audio controls src={file.url} className="w-full mt-1" />
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
+        </Rnd>
       )}
-
       {/* tldraw Canvas */}
       <Tldraw />
     </div>


### PR DESCRIPTION
- Added react-rnd for resizable and draggable audio files component
- Hid tldraw style panel (was in top left, blocking audio upload button), pages menu, and menu zone via CSS
- Update audio files heading to show song name for single files
- Add drag handle functionality and size constraints (250x200 to 600x800)

Problems 
-CSS Parser Conflicts, @theme rule was breaking CSS - fixed by placing rules after standard blocks

Takeaways
-!important is OK for third-party overrides - sometimes necessary for external libraries. Maybe find a better solution in the future, this seems like a quick fix that might cause issues later as the CSS gets more complex
-Z-index is hierarchical, not global - stacking contexts matter more than high numbers. Try to understand Z-index even better, inspect the hierarchy in more detail through dev tools in the browser.